### PR TITLE
Made project.d.json be able to be automatically made

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+out
+Project
+
+
 # Logs
 logs
 *.log
@@ -9,6 +13,7 @@ lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
 
 # Runtime data
 pids

--- a/README.md
+++ b/README.md
@@ -34,18 +34,30 @@ To build, you can use (surprisingly) `node src build`, which has the following f
 - `-7z / -7z_path string `: Path of the executable. Defaults to "7z".
 ### Project file structure
 
-Projects have a specific file structure that needs to be met so they can be compiled. The Project structure looks like something along these lines:
+Projects have a specific file structure that needs to be met so they can be compiled. 
+
+The Project structure looks like something along these lines:
 ```
 - Project
     - project.d.json
     - Sprite1.sprite
+        - images                (needed to automatically generate the json)
+            - image.png
         - main.js
 
     - Stage.background
         - myEpicFile.js
         - myAmazingFunction.js
+        - images                (needed to automatically generate the json)
+            - image2.png
 ```
 Every project **must** contain a `project.d.json`. It contains the sprites, costumes, and sounds that you want to import. An example of a `project.d.json`:
+
+It can be created automatically with `node src auto -i C:/AmazingScratchPrograms/Project`.
+For this to work a `images` folder **must** be included in the directory of the sprite/background.
+All of the .pngs in that directory will be included in the automatically generated `project.d.json` with their filenames as sprite names.
+**This deletes and replaces the old json and does not support sounds**
+
 ```json
 {
     "Sprite1": {

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ require arguments to make them work (E.g, when KEY pressed). These directives MU
 //#whenbroadcastreceived(Name: string) -> When broadcast received  -> Example: #whenbroadcastreceived("Message1")
 ```
 
+
 ### Additional functions
 
 There are additional functions that are not in native Scratch that exist:

--- a/src/boot.ts
+++ b/src/boot.ts
@@ -12,7 +12,7 @@
 import { new_args } from './lib/arg'
 import { argv } from 'process'
 import { errorMessages } from './lib/console'
-import { start_env } from './environment/env'
+import { start_env, regenerate_json } from './environment/env'
 import { DirectoryBuffer, FileBuffer } from './lib/fs';
 
 let subCommand = argv[2];
@@ -36,6 +36,9 @@ let argumentsCollected = new_args([
 ]);
 
 switch (subCommand) {
+    case "auto":
+        regenerate_json(argumentsCollected);
+        break;
     case "build":
         start_env(argumentsCollected);
         break;
@@ -43,15 +46,16 @@ switch (subCommand) {
     case "new":
         let newDir = new DirectoryBuffer("Project");
         let spriteDir = new DirectoryBuffer("Sprite1.sprite");
+        let spritImgeDir = new DirectoryBuffer("images");
         let spriteMain = new FileBuffer("main.js", "");
+        spriteDir.Append([spriteMain,spritImgeDir]);
         let projectJson = new FileBuffer("project.d.json", `{
-    "Sprite1": {
-        "Type": "Sprite",
-        "Costumes": [],
-        "Sounds": []
-    }
-}`)
-        spriteDir.Append([spriteMain]);
+        "Sprite1": {
+            "Type": "Sprite",
+            "Costumes": [],
+             "Sounds": []
+        }}`);
+
         newDir.Append([projectJson, spriteDir]);
 
         if (argumentsCollected["-i"] == "null") argumentsCollected["-i"] = "";

--- a/src/environment/env.ts
+++ b/src/environment/env.ts
@@ -20,6 +20,8 @@ import { createProject } from "../template/project";
 import { readFile } from "../lib/fs";
 import { Costume, Sound, Sprite } from "../class/Sprite";
 import chalk from "chalk";
+import { PassThrough } from "stream";
+import { json } from "stream/consumers";
 
 /**
  * Gets the directory from a given path.
@@ -40,17 +42,73 @@ function getDirectory(givenPath: string): string {
     return resolvedPath;
 }
 
+
+
+export function regenerate_json(arg: { [key: string]: string }) {
+
+    if (arg["-i"] == "null") errorMessages["No input directory"]();
+    let inputObject: string = arg["-i"];
+    let input = getDirectory(inputObject);
+
+    let projectJsonPath = path.join(input, 'project.d.json');
+    if (fs.existsSync(projectJsonPath)) {
+        fs.unlink(projectJsonPath, (err) => { if (err) errorMessages["How did you get here"](); });
+    }
+
+    let projectJsonNew = "{"
+
+    fs.readdirSync(input).forEach(file => {
+
+        if (file.slice(-7) == ".sprite" || file.slice(-11) == ".background") {
+            if (file.slice(-7) == ".sprite"){
+                projectJsonNew += `"${file.slice(0, -7)}": {"Type":"Sprite","Costumes":[`;
+            } else {
+                projectJsonNew += `"${file.slice(0, -11)}": {"Type":"Background","Costumes":[`;
+
+            }
+
+            let totalpath = path.join(path.join(input, file), "images");
+            let costumeJson = ""
+            if (fs.existsSync(totalpath)) {
+                //console.log("here")
+
+                fs.readdirSync(totalpath).forEach(image => {
+                    let imagepath = path.join(totalpath, image);
+                    //console.log(imagepath)
+                    if (image.slice(-4) == ".png")
+                        console.log(`image ${imagepath} in sprite ${file}`)
+                    costumeJson += `["${image.slice(0, -4)}","${imagepath.replace(/\\/g,"//")}"],`
+
+                });
+
+
+            } else {
+                console.log(`${file} is a sprite with no images`)
+
+            }
+            costumeJson = costumeJson.slice(0, -1)
+            costumeJson += "],"
+            projectJsonNew += costumeJson + `"Sounds":[]},`
+
+        }
+
+    });
+    
+    projectJsonNew = projectJsonNew.slice(0, -1)+"}"
+
+    fs.writeFileSync(projectJsonPath,projectJsonNew)
+}
+
 // Starts the JS2Scratch Environment.
-export function start_env(arg: { [key: string]: string })
-{
+export function start_env(arg: { [key: string]: string }) {
     if (arg["-i"] == "null") errorMessages["No input directory"]();
     let inputObject: string = arg["-i"];
 
     let input = getDirectory(inputObject);
     let isValid = validate.validateDirectorySchema(input);
-    
+
     if (!isValid.isValid) errorMessages["File Structure"](isValid.errors);
-    
+
     let sprites = [] as Sprite[]
 
     let projectInput = JSON.parse(readFile(path.join(input, 'project.d.json')));
@@ -66,12 +124,12 @@ export function start_env(arg: { [key: string]: string })
             "Building "
         )) + `${path.basename(inputObject)} - v0.0.1 - (${inputObject})`
     )
-        
+
 
     for (let i = 0; i < projectKeys.length; i++) {
         let sprite = projectValues[i] as { Type: string, Costumes: any[], Sounds: any[] };
         let isStage = sprite.Type === "Background";
-        let keyName = isStage ? "Stage" : projectKeys[i];        
+        let keyName = isStage ? "Stage" : projectKeys[i];
         let costumes: Costume[] = [];
         let sounds: Sound[] = [];
 
@@ -100,7 +158,7 @@ export function start_env(arg: { [key: string]: string })
         }
 
         let blocks = {};
-        
+
 
         for (const file of fs.readdirSync(inputObject)) {
             let fullPath = path.join(inputObject, file);
@@ -113,12 +171,14 @@ export function start_env(arg: { [key: string]: string })
                 let folderContents = fs.readdirSync(fullPath);
 
                 for (let i = 0; i < folderContents.length; i++) {
+                    if (!fs.statSync(path.join(fullPath,folderContents[i])).isDirectory()){
                     let object = path.join(fullPath, folderContents[i]);
-
+                    //console.log(object)
                     let base = path.basename(fullPath).toLowerCase().split(".");
                     if (base[1] == sprite.Type.toLowerCase() && base[0] == keyName.toLowerCase()) {
                         Object.assign(blocks, build.transpileFromSource(fs.readFileSync(object).toString(), object));
                     }
+                }
                 }
             }
         }
@@ -137,7 +197,7 @@ export function start_env(arg: { [key: string]: string })
         fs.unlinkSync(filePath);
     }
 
-    createProject(arg["-o"] != "null" && arg["-o"] || path.join(process.cwd(), 'out', ), 'Project', {
+    createProject(arg["-o"] != "null" && arg["-o"] || path.join(process.cwd(), 'out',), 'Project', {
         targets: sprites
     }, arg);
 }

--- a/src/lib/console.ts
+++ b/src/lib/console.ts
@@ -70,6 +70,9 @@ export const errorMessages = {
     "File Structure": ((Errors: string[]) => {
         error(-6, `The following errors occured while checking the project file structure and definition file:\n\n${Errors.join("\n")}\n\nTranspilation terminated.`);
     }),
+    "How did you get here": (() => {
+        error(-7, "How did you get here. This should be impossible")
+    }),
 
 
     //
@@ -109,5 +112,5 @@ export const errorMessages = {
 
     "Attempt to call unknown function": ((File: string, Constructor: string, fnName: string) => {
         error(9, `${File}: Attempt to call unknown function: ${Constructor}.${fnName}()`)
-    }),
+    })
 };

--- a/src/tmp/__git
+++ b/src/tmp/__git
@@ -1,1 +1,0 @@
-This file is here so Github doesn't delete this folder.


### PR DESCRIPTION
The "node src auto -i <Project folder" command automatically makes a project.json.
It names the sprites after the folders and the costumes after the images.
It looks for a folder called "images" in every sprite however that folder is not mandatory.
There may be edge cases i have not seen or error messages that i have not encountered but you know, it works on my mashine